### PR TITLE
Modernize tic-tac-toe contract to Move V2 syntax

### DIFF
--- a/move/Move.toml
+++ b/move/Move.toml
@@ -3,8 +3,11 @@ name = 'ExampleTicTacToe'
 version = '0.2.0'
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [addresses]
 deploy_account = "_"
+
+[dev-addresses]
+deploy_account = "0xCAFE"

--- a/move/sources/tic-tac-toe.move
+++ b/move/sources/tic-tac-toe.move
@@ -76,19 +76,19 @@ module deploy_account::tic_tac_toe {
         let spaces = vector::empty<u8>();
 
         // Row 1
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
 
         // Row 2
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
 
         // Row 3
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
-        vector::push_back(&mut spaces, NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
+        spaces.push_back(NONE);
 
         // Let's at least vary the starting player from X and O
         // TODO: Add better randomness, though it's a simple game
@@ -108,7 +108,7 @@ module deploy_account::tic_tac_toe {
         } else {
             // Check if game already exists
             let store = borrow_global<TicTacToeStore>(game_address);
-            assert!(!simple_map::contains_key<String, TicTacToe>(&store.games, &game_name), EGAME_ALREADY_EXISTS);
+            assert!(!store.games.contains_key(&game_name), EGAME_ALREADY_EXISTS);
         };
 
         let store = borrow_global_mut<TicTacToeStore>(game_address);
@@ -119,15 +119,15 @@ module deploy_account::tic_tac_toe {
             o_player
         };
 
-        simple_map::add(&mut store.games, game_name, game);
+        store.games.add(game_name, game);
     }
 
     /// Removes the game from the account
     public entry fun delete_game(game_signer: &signer, game_name: String) acquires TicTacToeStore {
         let game_address = address_of(game_signer);
         let store = get_store_mut(game_address);
-        assert!(simple_map::contains_key(&store.games, &game_name), EGAME_NOT_FOUND);
-        simple_map::remove(&mut store.games, &game_name);
+        assert!(store.games.contains_key(&game_name), EGAME_NOT_FOUND);
+        store.games.remove(&game_name);
     }
 
     /// Removes the tic-tac-toe store from the account and all associated games
@@ -153,10 +153,8 @@ module deploy_account::tic_tac_toe {
         assert!(winner != NONE, EGAME_NOT_OVER);
 
         // Reset all spaces to NONE
-        let i = 0;
-        while (i < 9) {
+        for (i in 0..9) {
             set_space(game, i, NONE);
-            i = i + 1;
         };
 
         // Next player is the loser, unless it's a draw, then whoever would be next
@@ -248,71 +246,71 @@ module deploy_account::tic_tac_toe {
         }
     }
 
-    inline fun get_store(game_address: address): &TicTacToeStore acquires TicTacToeStore {
+    inline fun get_store(game_address: address): &TicTacToeStore {
         assert!(exists<TicTacToeStore>(game_address), ESTORE_NOT_FOUND);
         borrow_global<TicTacToeStore>(game_address)
     }
 
-    inline fun get_store_mut(game_address: address): &mut TicTacToeStore acquires TicTacToeStore {
+    inline fun get_store_mut(game_address: address): &mut TicTacToeStore {
         assert!(exists<TicTacToeStore>(game_address), ESTORE_NOT_FOUND);
         borrow_global_mut<TicTacToeStore>(game_address)
     }
 
     /// Gets the game in a read only capacity, handling errors if not found
-    inline fun get_game(game_address: address, game_name: String): &TicTacToe acquires TicTacToeStore {
+    inline fun get_game(game_address: address, game_name: String): &TicTacToe {
         let store = get_store(game_address);
-        assert!(simple_map::contains_key(&store.games, &game_name), EGAME_NOT_FOUND);
-        simple_map::borrow(&store.games, &game_name)
+        assert!(store.games.contains_key(&game_name), EGAME_NOT_FOUND);
+        store.games.borrow(&game_name)
     }
 
     /// Gets the game in a mutating capacity, handling errors if not found
-    inline fun get_game_mut(game_address: address, game_name: String): &mut TicTacToe acquires TicTacToeStore {
+    inline fun get_game_mut(game_address: address, game_name: String): &mut TicTacToe {
         let store = get_store_mut(game_address);
-        assert!(simple_map::contains_key(&store.games, &game_name), EGAME_NOT_FOUND);
-        simple_map::borrow_mut(&mut store.games, &game_name)
+        assert!(store.games.contains_key(&game_name), EGAME_NOT_FOUND);
+        store.games.borrow_mut(&game_name)
     }
 
     /// Determine the winner (if any)
     inline fun evaluate_winner(game: &TicTacToe): u8 {
         // Collect all spaces
-        let upper_left = vector::borrow(&game.board, 0);
-        let upper_mid = vector::borrow(&game.board, 1);
-        let upper_right = vector::borrow(&game.board, 2);
-        let mid_left = vector::borrow(&game.board, 3);
-        let mid_mid = vector::borrow(&game.board, 4);
-        let mid_right = vector::borrow(&game.board, 5);
-        let lower_left = vector::borrow(&game.board, 6);
-        let lower_mid = vector::borrow(&game.board, 7);
-        let lower_right = vector::borrow(&game.board, 8);
+        let upper_left = game.board[0];
+        let upper_mid = game.board[1];
+        let upper_right = game.board[2];
+        let mid_left = game.board[3];
+        let mid_mid = game.board[4];
+        let mid_right = game.board[5];
+        let lower_left = game.board[6];
+        let lower_mid = game.board[7];
+        let lower_right = game.board[8];
 
         // Handle matches
-        if (*upper_left != NONE && *upper_left == *upper_mid && *upper_mid == *upper_right) {
+        if (upper_left != NONE && upper_left == upper_mid && upper_mid == upper_right) {
             // Upper row
-            *upper_left
-        } else if (*mid_left != NONE && *mid_left == *mid_mid && *mid_mid == *mid_right) {
+            upper_left
+        } else if (mid_left != NONE && mid_left == mid_mid && mid_mid == mid_right) {
             // Mid row
-            *mid_left
-        } else if (*lower_left != NONE && *lower_left == *lower_mid && *lower_mid == *lower_right) {
+            mid_left
+        } else if (lower_left != NONE && lower_left == lower_mid && lower_mid == lower_right) {
             // Lower row
-            *lower_left
-        } else if (*upper_left != NONE && *upper_left == *mid_left && *mid_left == *lower_left) {
+            lower_left
+        } else if (upper_left != NONE && upper_left == mid_left && mid_left == lower_left) {
             // Left col
-            *upper_left
-        } else if (*upper_mid != NONE && *upper_mid == *mid_mid && *mid_mid == *lower_mid) {
+            upper_left
+        } else if (upper_mid != NONE && upper_mid == mid_mid && mid_mid == lower_mid) {
             // Mid col
-            *upper_mid
-        } else if (*upper_right != NONE && *upper_right == *mid_right && *mid_right == *lower_right) {
+            upper_mid
+        } else if (upper_right != NONE && upper_right == mid_right && mid_right == lower_right) {
             // Right col
-            *upper_right
-        } else if (*upper_left != NONE && *upper_left == *mid_mid && *mid_mid == *lower_right) {
+            upper_right
+        } else if (upper_left != NONE && upper_left == mid_mid && mid_mid == lower_right) {
             // Upper left to lower right
-            *upper_left
-        } else if (*lower_left != NONE && *lower_left == *mid_mid && *mid_mid == *upper_right) {
+            upper_left
+        } else if (lower_left != NONE && lower_left == mid_mid && mid_mid == upper_right) {
             // Lower left to upper right
-            *upper_mid
-        } else if (*upper_left == NONE || *upper_mid == NONE || *upper_right == NONE ||
-            *mid_left == NONE || *mid_mid == NONE || *mid_right == NONE ||
-            *lower_left == NONE || *lower_mid == NONE || *lower_right == NONE) {
+            upper_mid
+        } else if (upper_left == NONE || upper_mid == NONE || upper_right == NONE ||
+            mid_left == NONE || mid_mid == NONE || mid_right == NONE ||
+            lower_left == NONE || lower_mid == NONE || lower_right == NONE) {
             // If all spaces are filled, game is over (TODO: We can be smarter than this on the draw condition and end early probably)
             NONE
         } else {
@@ -324,15 +322,14 @@ module deploy_account::tic_tac_toe {
     ///
     /// This allows for varying adjacency schemes of squares on the board.
     inline fun get_space(game: &TicTacToe, index: u64): u8 {
-        assert!(index < vector::length(&game.board), EOUT_OF_BOUNDS);
-        *vector::borrow(&game.board, index)
+        assert!(index < game.board.length(), EOUT_OF_BOUNDS);
+        game.board[index]
     }
 
     /// Sets a specific space given by an index to the new value.
     inline fun set_space(game: &mut TicTacToe, index: u64, new_value: u8) {
         // Must be within bounds of the fixed size board
-        assert!(index < vector::length(&game.board), EOUT_OF_BOUNDS);
-        let square = vector::borrow_mut(&mut game.board, index);
-        *square = new_value;
+        assert!(index < game.board.length(), EOUT_OF_BOUNDS);
+        game.board[index] = new_value;
     }
 }

--- a/move/tests/tic_tac_toe_tests.move
+++ b/move/tests/tic_tac_toe_tests.move
@@ -1,0 +1,489 @@
+#[test_only]
+module deploy_account::tic_tac_toe_tests {
+    use deploy_account::tic_tac_toe;
+    use std::string;
+    use aptos_framework::timestamp;
+
+    // Mirror constants from the main module
+    const NONE: u8 = 0;
+    const X: u8 = 1;
+    const O: u8 = 2;
+
+    fun setup(aptos_framework: &signer) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        // After this, now_microseconds() == 0, so 0 % 2 == 0, meaning X goes first
+    }
+
+    fun game_name(): string::String {
+        string::utf8(b"test_game")
+    }
+
+    // ============ Happy Path Tests ============
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_start_game(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        let board = tic_tac_toe::get_board(@0xCAFE, game_name());
+        for (i in 0..9) {
+            assert!(board[i] == NONE, i);
+        };
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_play_and_get_board(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X goes first (timestamp is 0, 0 % 2 == 0 -> X)
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        let board = tic_tac_toe::get_board(@0xCAFE, game_name());
+        assert!(board[0] == X, 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_x_wins_top_row(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X goes first. X: 0, O: 3, X: 1, O: 4, X: 2 (top row win)
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        let (winner, addr) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == X, 0);
+        assert!(addr == @0x100, 1);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_o_wins_mid_row(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X: 0, O: 3, X: 1, O: 4, X: 6, O: 5 (O wins mid row 3-4-5)
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 6);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 5);
+
+        let (winner, addr) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == O, 0);
+        assert!(addr == @0x200, 1);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_diagonal_win(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X: 0, O: 1, X: 4, O: 2, X: 8 (diagonal 0-4-8)
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 2);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 8);
+
+        let (winner, _) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == X, 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_column_win(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X: 0, O: 1, X: 3, O: 4, X: 6 (left column 0-3-6)
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 6);
+
+        let (winner, _) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == X, 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_players_view(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        let (x_addr, o_addr) = tic_tac_toe::players(@0xCAFE, game_name());
+        assert!(x_addr == @0x100, 0);
+        assert!(o_addr == @0x200, 1);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_current_player_view(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X goes first (timestamp 0 % 2 == 0)
+        let (current, addr) = tic_tac_toe::current_player(@0xCAFE, game_name());
+        assert!(current == X, 0);
+        assert!(addr == @0x100, 1);
+
+        // After X plays, O is current
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        let (current2, addr2) = tic_tac_toe::current_player(@0xCAFE, game_name());
+        assert!(current2 == O, 2);
+        assert!(addr2 == @0x200, 3);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_winner_none_at_start(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        let (winner, _) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == NONE, 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_current_player_none_after_win(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X wins top row
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        let (current, addr) = tic_tac_toe::current_player(@0xCAFE, game_name());
+        assert!(current == NONE, 0);
+        assert!(addr == @0, 1);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_reset_game_after_win(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X wins top row
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        // Admin resets the game
+        tic_tac_toe::reset_game(game_admin, @0xCAFE, game_name());
+
+        // Board should be empty
+        let board = tic_tac_toe::get_board(@0xCAFE, game_name());
+        for (i in 0..9) {
+            assert!(board[i] == NONE, i);
+        };
+
+        // Winner should be NONE
+        let (winner, _) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == NONE, 100);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    fun test_player_resets_after_win(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = game_admin;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X wins top row
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        // O player resets (loser can reset)
+        tic_tac_toe::reset_game(player_o, @0xCAFE, game_name());
+
+        let (winner, _) = tic_tac_toe::winner(@0xCAFE, game_name());
+        assert!(winner == NONE, 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    fun test_delete_game(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        tic_tac_toe::delete_game(game_admin, game_name());
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    fun test_delete_store(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        tic_tac_toe::delete_store(game_admin);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    fun test_multiple_games(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, string::utf8(b"game1"), @0x100, @0x200);
+        tic_tac_toe::start_game(game_admin, string::utf8(b"game2"), @0x300, @0x400);
+
+        let (x1, o1) = tic_tac_toe::players(@0xCAFE, string::utf8(b"game1"));
+        let (x2, o2) = tic_tac_toe::players(@0xCAFE, string::utf8(b"game2"));
+        assert!(x1 == @0x100 && o1 == @0x200, 0);
+        assert!(x2 == @0x300 && o2 == @0x400, 1);
+    }
+
+    // ============ Error Path Tests ============
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    #[expected_failure(abort_code = 11, location = deploy_account::tic_tac_toe)]
+    fun test_same_player_both_sides(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x100);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    #[expected_failure(abort_code = 9, location = deploy_account::tic_tac_toe)]
+    fun test_duplicate_game(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x300, @0x400);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    #[expected_failure(abort_code = 7, location = deploy_account::tic_tac_toe)]
+    fun test_space_already_played(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X plays at 0
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        // O tries to play at 0 (already occupied)
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    #[expected_failure(abort_code = 1, location = deploy_account::tic_tac_toe)]
+    fun test_reset_game_not_over(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        tic_tac_toe::reset_game(game_admin, @0xCAFE, game_name());
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, attacker = @0xEE)]
+    #[expected_failure(abort_code = 13, location = deploy_account::tic_tac_toe)]
+    fun test_play_nonexistent_store(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        attacker: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = game_admin;
+        tic_tac_toe::play_space(attacker, @0xCAFE, game_name(), 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    #[expected_failure(abort_code = 8, location = deploy_account::tic_tac_toe)]
+    fun test_delete_nonexistent_game(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, string::utf8(b"other"), @0x100, @0x200);
+        tic_tac_toe::delete_game(game_admin, game_name());
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    #[expected_failure(abort_code = 13, location = deploy_account::tic_tac_toe)]
+    fun test_delete_store_not_found(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = game_admin;
+        tic_tac_toe::delete_store(game_admin);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200, stranger = @0xEE)]
+    #[expected_failure(abort_code = 3, location = deploy_account::tic_tac_toe)]
+    fun test_invalid_player(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+        stranger: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        let _ = player_o;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        tic_tac_toe::play_space(stranger, @0xCAFE, game_name(), 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    #[expected_failure(abort_code = 5, location = deploy_account::tic_tac_toe)]
+    fun test_wrong_turn_o_plays_on_x_turn(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        let _ = player_x;
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+        // X goes first, so O playing first should fail
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 0);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200, stranger = @0xEE)]
+    #[expected_failure(abort_code = 10, location = deploy_account::tic_tac_toe)]
+    fun test_invalid_resetter(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+        stranger: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X wins top row
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        // Stranger tries to reset
+        tic_tac_toe::reset_game(stranger, @0xCAFE, game_name());
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE, player_x = @0x100, player_o = @0x200)]
+    #[expected_failure(abort_code = 6, location = deploy_account::tic_tac_toe)]
+    fun test_play_after_game_over(
+        aptos_framework: &signer,
+        game_admin: &signer,
+        player_x: &signer,
+        player_o: &signer,
+    ) {
+        setup(aptos_framework);
+        tic_tac_toe::start_game(game_admin, game_name(), @0x100, @0x200);
+
+        // X wins top row
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 0);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 3);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 1);
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 4);
+        tic_tac_toe::play_space(player_x, @0xCAFE, game_name(), 2);
+
+        // Try to play after game over
+        tic_tac_toe::play_space(player_o, @0xCAFE, game_name(), 5);
+    }
+
+    #[test(aptos_framework = @0x1, game_admin = @0xCAFE)]
+    #[expected_failure(abort_code = 14, location = deploy_account::tic_tac_toe)]
+    fun test_framework_address_player(
+        aptos_framework: &signer,
+        game_admin: &signer,
+    ) {
+        setup(aptos_framework);
+        // @0xA is a framework reserved address
+        tic_tac_toe::start_game(game_admin, game_name(), @0xA, @0x200);
+    }
+}


### PR DESCRIPTION
## Summary
- Convert while loops with counters to for-range loops
- Replace `vector::borrow`/`borrow_mut` with index notation
- Replace `vector::push_back`/`length` and `simple_map::` calls with receiver style
- Remove unnecessary `acquires` on inline functions
- Add test suite with 27 tests covering happy paths and error cases
- Fix Move.toml: pin AptosFramework to `mainnet` rev, add dev-addresses

## Test plan
- [x] All 27 tests pass (`aptos move test`)
- [ ] Verify deployment to devnet still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)